### PR TITLE
common: print count of replaced api objects

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -82,20 +82,14 @@ func ReplaceManifestUnSupportedAPIs(origManifest, mapFile string, kubeConfig Kub
 			return "", errors.Errorf("Failed to get the deprecated or removed Kubernetes version for API: %s", strings.ReplaceAll(deprecatedAPI, "\n", " "))
 		}
 
-		var modManifestForAPI string
-		var modified = false
-		modManifestForAPI = strings.ReplaceAll(modifiedManifest, deprecatedAPI, supportedAPI)
-		if modManifestForAPI != modifiedManifest {
-			modified = true
-			log.Printf("Found deprecated or removed Kubernetes API:\n\"%s\"\nSupported API equivalent:\n\"%s\"\n", deprecatedAPI, supportedAPI)
-		}
-		if modified {
+		if count := strings.Count(modifiedManifest, deprecatedAPI); count > 0 {
 			if semver.Compare(apiVersionStr, kubeVersionStr) > 0 {
 				log.Printf("The following API does not require mapping as the "+
 					"API is not deprecated or removed in Kubernetes '%s':\n\"%s\"\n", apiVersionStr,
 					deprecatedAPI)
 			} else {
-				modifiedManifest = modManifestForAPI
+				log.Printf("Replacing %d instances of deprecated or removed Kubernetes API:\n\"%s\"\nSupported API equivalent:\n\"%s\"\n", count, deprecatedAPI, supportedAPI)
+				modifiedManifest = strings.ReplaceAll(modifiedManifest, deprecatedAPI, supportedAPI)
 			}
 		}
 	}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -88,7 +88,7 @@ func ReplaceManifestUnSupportedAPIs(origManifest, mapFile string, kubeConfig Kub
 					"API is not deprecated or removed in Kubernetes '%s':\n\"%s\"\n", apiVersionStr,
 					deprecatedAPI)
 			} else {
-				log.Printf("Replacing %d instances of deprecated or removed Kubernetes API:\n\"%s\"\nSupported API equivalent:\n\"%s\"\n", count, deprecatedAPI, supportedAPI)
+				log.Printf("Found %d instances of deprecated or removed Kubernetes API:\n\"%s\"\nSupported API equivalent:\n\"%s\"\n", count, deprecatedAPI, supportedAPI)
 				modifiedManifest = strings.ReplaceAll(modifiedManifest, deprecatedAPI, supportedAPI)
 			}
 		}

--- a/pkg/v2/release.go
+++ b/pkg/v2/release.go
@@ -57,7 +57,7 @@ func MapReleaseWithUnSupportedAPIs(mapOptions common.MapOptions) error {
 	}
 
 	if mapOptions.DryRun {
-		log.Printf("Deprecated or removed APIs exist, no changes will be made to release: %s.\n", releaseName)
+		log.Printf("Deprecated or removed APIs exist, for release: %s.\n", releaseName)
 	} else {
 		log.Printf("Deprecated or removed APIs exist, updating release: %s.\n", releaseName)
 		if err := updateRelease(releaseToMap, modifiedManifest, storageDriver); err != nil {

--- a/pkg/v2/release.go
+++ b/pkg/v2/release.go
@@ -56,8 +56,10 @@ func MapReleaseWithUnSupportedAPIs(mapOptions common.MapOptions) error {
 		return nil
 	}
 
-	log.Printf("Deprecated or removed APIs exist, updating release: %s.\n", releaseName)
-	if !mapOptions.DryRun {
+	if mapOptions.DryRun {
+		log.Printf("Deprecated or removed APIs exist, no changes will be made to release: %s.\n", releaseName)
+	} else {
+		log.Printf("Deprecated or removed APIs exist, updating release: %s.\n", releaseName)
 		if err := updateRelease(releaseToMap, modifiedManifest, storageDriver); err != nil {
 			return errors.Wrapf(err, "Failed to update release '%s'", releaseName)
 		}

--- a/pkg/v3/release.go
+++ b/pkg/v3/release.go
@@ -55,8 +55,10 @@ func MapReleaseWithUnSupportedAPIs(mapOptions common.MapOptions) error {
 		return nil
 	}
 
-	log.Printf("Deprecated or removed APIs exist, updating release: %s.\n", releaseName)
-	if !mapOptions.DryRun {
+	if mapOptions.DryRun {
+		log.Printf("Deprecated or removed APIs exist, no changes will be made to release: %s.\n", releaseName)
+	} else {
+		log.Printf("Deprecated or removed APIs exist, updating release: %s.\n", releaseName)
 		if err := updateRelease(releaseToMap, modifiedManifest, cfg); err != nil {
 			return errors.Wrapf(err, "failed to update release '%s'", releaseName)
 		}

--- a/pkg/v3/release.go
+++ b/pkg/v3/release.go
@@ -56,7 +56,7 @@ func MapReleaseWithUnSupportedAPIs(mapOptions common.MapOptions) error {
 	}
 
 	if mapOptions.DryRun {
-		log.Printf("Deprecated or removed APIs exist, no changes will be made to release: %s.\n", releaseName)
+		log.Printf("Deprecated or removed APIs exist, for release: %s.\n", releaseName)
 	} else {
 		log.Printf("Deprecated or removed APIs exist, updating release: %s.\n", releaseName)
 		if err := updateRelease(releaseToMap, modifiedManifest, cfg); err != nil {


### PR DESCRIPTION
Print a count of how many objects were replaced when a deprecated API is found.
This is helpful to see that the correct number of instances were matched.