### PR TITLE
Added MutatingWebhookConfiguration to Map.yaml

### DIFF
--- a/config/Map.yaml
+++ b/config/Map.yaml
@@ -187,4 +187,8 @@ mappings:
     newAPI: "apiVersion: storage.k8s.io/v1\nkind: VolumeAttachment\n"
     deprecatedInVersion: "v1.13"
     removedInVersion: "v1.22"
+  - deprecatedAPI: "apiVersion: admissionregistration.k8s.io/v1beta1\nkind: MutatingWebhookConfiguration\n"
+    newAPI: "apiVersion: admissionregistration.k8s.io/v1\nkind: MutatingWebhookConfiguration\n"
+    deprecatedInVersion: "v1.16"
+    removedInVersion: "v1.22"
 


### PR DESCRIPTION
admissionregistration.k8s.io/v1beta1 (kind: MutatingWebhookConfiguration) has been deprecated. New version is admissionregistration.k8s.io/v1 from k8s v1.22

see [here](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22)