### PR TITLE
Parse kind and apiVersion anywhere in the document

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     working_directory: /go/src/github.com/helm/helm-mapkubeapis
     steps:
       - checkout
-      - run: make build
+      - run: make test && make build
   tagged-build:
     docker:
       - image: circleci/golang:1.17

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ build:
 	export CGO_ENABLED=0 && \
 	go build -o bin/${HELM_PLUGIN_NAME} -ldflags $(LDFLAGS) ./cmd/mapkubeapis
 
+.PHONY: test
+test:
+	go test ./...
+
 .PHONY: bootstrap
 bootstrap:
 	export GO111MODULE=on && \

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ ./linux-amd64/helm plugin install https://github.com/helm/helm-mapkubeapis
 Map release deprecated or removed Kubernetes APIs in-place:
 
 ```console
-$ helm mapkubeapis [flags] RELEASE 
+$ helm mapkubeapis [flags] RELEASE
 
 Flags:
       --dry-run                  simulate a command
@@ -59,7 +59,7 @@ Flags:
 Example output:
 
 ```console
-$ helm mapkubeapis cluster-role-example --namespace test-cluster-role-example         
+$ helm mapkubeapis cluster-role-example --namespace test-cluster-role-example
 2022/02/07 18:48:49 Release 'cluster-role-example' will be checked for deprecated or removed Kubernetes APIs and will be updated if necessary to supported API versions.
 2022/02/07 18:48:49 Get release 'cluster-role-example' latest version.
 2022/02/07 18:48:49 Check release 'cluster-role-example' for deprecated or removed APIs...
@@ -94,17 +94,20 @@ kind: ClusterRoleBinding
 The mapping information of deprecated or removed APIs to supported APIs is configured in the [Map.yaml](https://github.com/helm/helm-mapkubeapis/blob/master/config/Map.yaml) file. The file is a list of entries similar to the following:
 
 ```yaml
- - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: Deployment"
-    newAPI: "apiVersion: apps/v1\nkind: Deployment"
-    deprecatedInVersion: "v1.9"
-    removedInVersion: "v1.16"
+- deprecatedAPI:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+  newAPI:
+    apiVersion: apps/v1
+    kind: Deployment
+  deprecatedInVersion: "v1.9"
+  removedInVersion: "v1.16"
 ```
 
 The plugin when performing update of a Helm release metadata first loads the map file from the `config` directory where the plugin is run from. If the map file is a different name or in a different location, you can use the `--mapfile` flag to specify the different mapping file.
 
 The OOTB mapping file is configured as follows:
 
-- The search and replace strings are in order with `apiVersion` first and then `kind`. This should be changed if the Helm release metadata is rendered with different search/replace string.
 - The strings contain UNIX/Linux line feeds. This means that `\n` is used to signify line separation between properties in the strings. This should be changed if the Helm release metadata is rendered in Windows or Mac.
 - Each mapping contains the Kubernetes version that the API is deprecated and removed in. This information is important as the plugin checks that the deprecated version (uses removed if deprecated unset) is later than the Kubernetes version that it is running against. If it is then no mapping occurs for this API as it not yet deprecated in this Kubernetes version and hence the new API is not yet supported. Otherwise, the mapping can proceed.
 

--- a/config/Map.yaml
+++ b/config/Map.yaml
@@ -1,190 +1,377 @@
 mappings:
-  - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: Deployment\n"
-    newAPI: "apiVersion: apps/v1\nkind: Deployment\n"
+  - deprecatedAPI:
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+    newAPI:
+      apiVersion: apps/v1
+      kind: Deployment
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: apps/v1beta1\nkind: Deployment\n"
-    newAPI: "apiVersion: apps/v1\nkind: Deployment\n"
+  - deprecatedAPI:
+      apiVersion: apps/v1beta1
+      kind: Deployment
+    newAPI:
+      apiVersion: apps/v1
+      kind: Deployment
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: apps/v1beta2\nkind: Deployment\n"
-    newAPI: "apiVersion: apps/v1\nkind: Deployment\n"
+  - deprecatedAPI:
+      apiVersion: apps/v1beta2
+      kind: Deployment
+    newAPI:
+      apiVersion: apps/v1
+      kind: Deployment
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: apps/v1beta1\nkind: StatefulSet\n"
-    newAPI: "apiVersion: apps/v1\nkind: StatefulSet\n"
+  - deprecatedAPI:
+      apiVersion: apps/v1beta1
+      kind: StatefulSet
+    newAPI:
+      apiVersion: apps/v1
+      kind: StatefulSet
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: apps/v1beta2\nkind: StatefulSet\n"
-    newAPI: "apiVersion: apps/v1\nkind: StatefulSet\n"
+  - deprecatedAPI:
+      apiVersion: apps/v1beta2
+      kind: StatefulSet
+    newAPI:
+      apiVersion: apps/v1
+      kind: StatefulSet
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: DaemonSet\n"
-    newAPI: "apiVersion: apps/v1\nkind: DaemonSet\n"
+  - deprecatedAPI:
+      apiVersion: extensions/v1beta1
+      kind: DaemonSet
+    newAPI:
+      apiVersion: apps/v1
+      kind: DaemonSet
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: apps/v1beta2\nkind: DaemonSet\n"
-    newAPI: "apiVersion: apps/v1\nkind: DaemonSet\n"
+  - deprecatedAPI:
+      apiVersion: apps/v1beta2
+      kind: DaemonSet
+    newAPI:
+      apiVersion: apps/v1
+      kind: DaemonSet
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: ReplicaSet\n"
-    newAPI: "apiVersion: apps/v1\nkind: ReplicaSet\n"
+  - deprecatedAPI:
+      apiVersion: extensions/v1beta1
+      kind: ReplicaSet
+    newAPI:
+      apiVersion: apps/v1
+      kind: ReplicaSet
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: apps/v1beta1\nkind: ReplicaSet\n"
-    newAPI: "apiVersion: apps/v1\nkind: ReplicaSet\n"
+  - deprecatedAPI:
+      apiVersion: apps/v1beta1
+      kind: ReplicaSet
+    newAPI:
+      apiVersion: apps/v1
+      kind: ReplicaSet
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: apps/v1beta2\nkind: ReplicaSet\n"
-    newAPI: "apiVersion: apps/v1\nkind: ReplicaSet\n"
+  - deprecatedAPI:
+      apiVersion: apps/v1beta2
+      kind: ReplicaSet
+    newAPI:
+      apiVersion: apps/v1
+      kind: ReplicaSet
     deprecatedInVersion: "v1.9"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: NetworkPolicy\n"
-    newAPI: "apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\n"
+  - deprecatedAPI:
+      apiVersion: extensions/v1beta1
+      kind: NetworkPolicy
+    newAPI:
+      apiVersion: networking.k8s.io/v1
+      kind: NetworkPolicy
     deprecatedInVersion: "v1.8"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: PodSecurityPolicy\n"
-    newAPI: "apiVersion: policy/v1beta1\nkind: PodSecurityPolicy\n"
+  - deprecatedAPI:
+      apiVersion: extensions/v1beta1
+      kind: PodSecurityPolicy
+    newAPI:
+      apiVersion: policy/v1beta1
+      kind: PodSecurityPolicy
     deprecatedInVersion: "v1.10"
     removedInVersion: "v1.16"
-  - deprecatedAPI: "apiVersion: admissionregistration.k8s.io/v1beta1\nkind: MutatingWebhookConfiguration\n"
-    newAPI: "apiVersion: admissionregistration.k8s.io/v1\nkind: MutatingWebhookConfiguration\n"
+  - deprecatedAPI:
+      apiVersion: admissionregistration.k8s.io/v1beta1
+      kind: MutatingWebhookConfiguration
+    newAPI:
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: MutatingWebhookConfiguration
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: admissionregistration.k8s.io/v1beta1\nkind: ValidatingWebhookConfiguration\n"
-    newAPI: "apiVersion: admissionregistration.k8s.io/v1\nkind: ValidatingWebhookConfiguration\n"
+  - deprecatedAPI:
+      apiVersion: admissionregistration.k8s.io/v1beta1
+      kind: ValidatingWebhookConfiguration
+    newAPI:
+      apiVersion: admissionregistration.k8s.io/v1
+      kind: ValidatingWebhookConfiguration
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: apiextensions.k8s.io/v1beta1\nkind: CustomResourceDefinition\n"
-    newAPI: "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\n"
+  - deprecatedAPI:
+      apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+    newAPI:
+      apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: apiregistration.k8s.io/v1beta1\nkind: APIService\n"
-    newAPI: "apiVersion: apiregistration.k8s.io/v1\nkind: APIService\n"
+  - deprecatedAPI:
+      apiVersion: apiregistration.k8s.io/v1beta1
+      kind: APIService
+    newAPI:
+      apiVersion: apiregistration.k8s.io/v1
+      kind: APIService
     deprecatedInVersion: "v1.19"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: apiregistration.k8s.io/v1beta1\nkind: APIServiceList\n"
-    newAPI: "apiVersion: apiregistration.k8s.io/v1\nkind: APIServiceList\n"
+  - deprecatedAPI:
+      apiVersion: apiregistration.k8s.io/v1beta1
+      kind: APIServiceList
+    newAPI:
+      apiVersion: apiregistration.k8s.io/v1
+      kind: APIServiceList
     deprecatedInVersion: "v1.19"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: authentication.k8s.io/v1beta1\nkind: TokenReview\n"
-    newAPI: "apiVersion: authentication.k8s.io/v1\nkind: TokenReview\n"
+  - deprecatedAPI:
+      apiVersion: authentication.k8s.io/v1beta1
+      kind: TokenReview
+    newAPI:
+      apiVersion: authentication.k8s.io/v1
+      kind: TokenReview
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: authorization.k8s.io/v1beta1\nkind: LocalSubjectAccessReview\n"
-    newAPI: "apiVersion: authorization.k8s.io/v1\nkind: LocalSubjectAccessReview\n"
+  - deprecatedAPI:
+      apiVersion: authorization.k8s.io/v1beta1
+      kind: LocalSubjectAccessReview
+    newAPI:
+      apiVersion: authorization.k8s.io/v1
+      kind: LocalSubjectAccessReview
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: authorization.k8s.io/v1beta1\nkind: SelfSubjectAccessReview\n"
-    newAPI: "apiVersion: authorization.k8s.io/v1\nkind: SelfSubjectAccessReview\n"
+  - deprecatedAPI:
+      apiVersion: authorization.k8s.io/v1beta1
+      kind: SelfSubjectAccessReview
+    newAPI:
+      apiVersion: authorization.k8s.io/v1
+      kind: SelfSubjectAccessReview
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: authorization.k8s.io/v1beta1\nkind: SubjectAccessReview\n"
-    newAPI: "apiVersion: authorization.k8s.io/v1\nkind: SubjectAccessReview\n"
+  - deprecatedAPI:
+      apiVersion: authorization.k8s.io/v1beta1
+      kind: SubjectAccessReview
+    newAPI:
+      apiVersion: authorization.k8s.io/v1
+      kind: SubjectAccessReview
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: certificates.k8s.io/v1beta1\nkind: CertificateSigningRequest\n"
-    newAPI: "apiVersion: certificates.k8s.io/v1\nkind: CertificateSigningRequest\n"
+  - deprecatedAPI:
+      apiVersion: certificates.k8s.io/v1beta1
+      kind: CertificateSigningRequest
+    newAPI:
+      apiVersion: certificates.k8s.io/v1
+      kind: CertificateSigningRequest
     deprecatedInVersion: "v1.19"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: coordination.k8s.io/v1beta1\nkind: Lease\n"
-    newAPI: "apiVersion: coordination.k8s.io/v1\nkind: Lease\n"
+  - deprecatedAPI:
+      apiVersion: coordination.k8s.io/v1beta1
+      kind: Lease
+    newAPI:
+      apiVersion: coordination.k8s.io/v1
+      kind: Lease
     deprecatedInVersion: "v1.14"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: Ingress\n"
-    newAPI: "apiVersion: networking.k8s.io/v1beta1\nkind: Ingress\n"
+  - deprecatedAPI:
+      apiVersion: extensions/v1beta1
+      kind: Ingress
+    newAPI:
+      apiVersion: networking.k8s.io/v1beta1
+      kind: Ingress
     deprecatedInVersion: "v1.14"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: networking.k8s.io/v1beta1\nkind: Ingress\n"
-    newAPI: "apiVersion: networking.k8s.io/v1\nkind: Ingress\n"
+  - deprecatedAPI:
+      apiVersion: networking.k8s.io/v1beta1
+      kind: Ingress
+    newAPI:
+      apiVersion: networking.k8s.io/v1
+      kind: Ingress
     deprecatedInVersion: "v1.19"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: networking.k8s.io/v1beta1\nkind: IngressClass\n"
-    newAPI: "apiVersion: networking.k8s.io/v1\nkind: IngressClass\n"
+  - deprecatedAPI:
+      apiVersion: networking.k8s.io/v1beta1
+      kind: IngressClass
+    newAPI:
+      apiVersion: networking.k8s.io/v1
+      kind: IngressClass
     deprecatedInVersion: "v1.19"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: ClusterRole\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: ClusterRole
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: ClusterRoleList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: ClusterRoleList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: ClusterRoleBinding\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: ClusterRoleBinding
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: ClusterRoleBindingList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBindingList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: ClusterRoleBindingList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBindingList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: Role\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: Role\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: Role
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: RoleList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: RoleList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: RoleList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: RoleBinding\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: RoleBinding
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1alpha1\nkind: RoleBindingList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBindingList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1alpha1
+      kind: RoleBindingList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBindingList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: ClusterRole\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRole\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRole
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: ClusterRoleList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRoleList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: ClusterRoleBinding\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRoleBinding
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: ClusterRoleBindingList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: ClusterRoleBindingList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: ClusterRoleBindingList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBindingList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: Role\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: Role\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: Role
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: Role
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: RoleList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: RoleList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: RoleList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: RoleBinding\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: RoleBinding
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBinding
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: rbac.authorization.k8s.io/v1beta1\nkind: RoleBindingList\n"
-    newAPI: "apiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBindingList\n"
+  - deprecatedAPI:
+      apiVersion: rbac.authorization.k8s.io/v1beta1
+      kind: RoleBindingList
+    newAPI:
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: RoleBindingList
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: scheduling.k8s.io/v1beta1\nkind: PriorityClass\n"
-    newAPI: "apiVersion: scheduling.k8s.io/v1\nkind: PriorityClass\n"
+  - deprecatedAPI:
+      apiVersion: scheduling.k8s.io/v1beta1
+      kind: PriorityClass
+    newAPI:
+      apiVersion: scheduling.k8s.io/v1
+      kind: PriorityClass
     deprecatedInVersion: "v1.14"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: storage.k8s.io/v1beta1\nkind: CSIDriver\n"
-    newAPI: "apiVersion: storage.k8s.io/v1\nkind: CSIDriver\n"
+  - deprecatedAPI:
+      apiVersion: storage.k8s.io/v1beta1
+      kind: CSIDriver
+    newAPI:
+      apiVersion: storage.k8s.io/v1
+      kind: CSIDriver
     deprecatedInVersion: "v1.19"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: storage.k8s.io/v1beta1\nkind: CSINode\n"
-    newAPI: "apiVersion: storage.k8s.io/v1\nkind: CSINode\n"
+  - deprecatedAPI:
+      apiVersion: storage.k8s.io/v1beta1
+      kind: CSINode
+    newAPI:
+      apiVersion: storage.k8s.io/v1
+      kind: CSINode
     deprecatedInVersion: "v1.17"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: storage.k8s.io/v1beta1\nkind: StorageClass\n"
-    newAPI: "apiVersion: storage.k8s.io/v1\nkind: StorageClass\n"
+  - deprecatedAPI:
+      apiVersion: storage.k8s.io/v1beta1
+      kind: StorageClass
+    newAPI:
+      apiVersion: storage.k8s.io/v1
+      kind: StorageClass
     deprecatedInVersion: "v1.16"
     removedInVersion: "v1.22"
-  - deprecatedAPI: "apiVersion: storage.k8s.io/v1beta1\nkind: VolumeAttachment\n"
-    newAPI: "apiVersion: storage.k8s.io/v1\nkind: VolumeAttachment\n"
+  - deprecatedAPI:
+      apiVersion: storage.k8s.io/v1beta1
+      kind: VolumeAttachment
+    newAPI:
+      apiVersion: storage.k8s.io/v1
+      kind: VolumeAttachment
     deprecatedInVersion: "v1.13"
     removedInVersion: "v1.22"
-

--- a/fixtures/expected-manifest.yaml
+++ b/fixtures/expected-manifest.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: scheduling.k8s.io/v1
+description: important-priorityclass critical
+globalDefault: false
+kind: PriorityClass
+metadata:
+  labels:
+    team: mapkubeapis
+  name: important-priorityclass-critical
+value: 1000000000
+---
+apiVersion: v1
+description: "the basic nginx-deployment from the kube docs"
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+  app: nginx
+spec:
+  replicas: 3
+  selector:
+  matchLabels:
+    app: nginx
+  template:
+  metadata:
+    labels:
+    app: nginx
+  spec:
+    containers:
+    - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80

--- a/fixtures/test-map.yaml
+++ b/fixtures/test-map.yaml
@@ -1,0 +1,17 @@
+mappings:
+  - deprecatedAPI:
+      apiVersion: extensions/v1beta1
+      kind: Deployment
+    newAPI:
+      apiVersion: apps/v1
+      kind: Deployment
+    deprecatedInVersion: "v1.9"
+    removedInVersion: "v1.16"
+  - deprecatedAPI:
+      apiVersion: scheduling.k8s.io/v1beta1
+      kind: PriorityClass
+    newAPI:
+      apiVersion: scheduling.k8s.io/v1
+      kind: PriorityClass
+    deprecatedInVersion: "v1.14"
+    removedInVersion: "v1.22"

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,50 @@
+package common_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/helm/helm-mapkubeapis/pkg/common"
+)
+
+const (
+	basicDeployment = `
+---
+apiVersion: extensions/v1beta1
+description: "the basic nginx-deployment from the kube docs"
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+  app: nginx
+spec:
+  replicas: 3
+  selector:
+  matchLabels:
+    app: nginx
+  template:
+  metadata:
+    labels:
+    app: nginx
+  spec:
+    containers:
+    - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+`
+)
+
+func TestReplaceManifestUnSupportedAPIs(t *testing.T) {
+	multidocManifest := basicDeployment + basicPriorityClass
+	newManifest, err := common.ReplaceManifestUnSupportedAPIs(multidocManifest, "../../fixtures/test-map.yaml", "v1.22")
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+
+	if strings.Contains(newManifest, "extensions/v1beta1") || strings.Contains(newManifest, "scheduling.k8s.io/v1beta1") {
+		t.Fail()
+		t.Log(newManifest)
+	}
+}

--- a/pkg/common/manifest.go
+++ b/pkg/common/manifest.go
@@ -10,12 +10,21 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// Manifest is used to grab the minimum information from a resources.
+// The Rest
 type Manifest struct {
-	APIVersion     string                 `json:"apiVersion"`
-	Kind           string                 `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+
+	// RestOfManifest will hold all other data in the resources
+	// yaml document. For example, everything in spec, metadata,
+	// or any other key in the document.
 	RestOfManifest map[string]interface{} `json:"-"`
 }
 
+// UnmarshallManifest will parse the apiVersion and kind from a yaml document,
+// then parse the rest of the document. Finally, we'll put it into a Manifest
+// that we can easily use to check if resources need updates.
 func UnmarshallManifest(manifest string) (*Manifest, error) {
 	m := Manifest{}
 
@@ -32,6 +41,8 @@ func UnmarshallManifest(manifest string) (*Manifest, error) {
 	return &m, nil
 }
 
+// Marshall will transform a manifest into a string with a prepended
+// yaml doc seperator ---
 func (m *Manifest) Marshall() (string, error) {
 	nm, err := yaml.Marshal(m)
 	if err != nil {
@@ -47,7 +58,7 @@ func (m *Manifest) Marshall() (string, error) {
 	return "---\n" + newManifest + restOfManifest, nil
 }
 
-// CheckAllMappings takes a yaml document, not the entire manifest checks if any of the mappings
+// CheckAllMappings takes a yaml document, not the entire manifest, and checks if any of the mappings
 // will update it.
 func CheckAllMappings(yamlDocument string, mappings []*mapping.Mapping, kubeVersionStr string) (string, error) {
 	m, err := UnmarshallManifest(yamlDocument)

--- a/pkg/common/manifest.go
+++ b/pkg/common/manifest.go
@@ -1,0 +1,96 @@
+package common
+
+import (
+	"log"
+	"strings"
+
+	"github.com/helm/helm-mapkubeapis/pkg/mapping"
+	"github.com/pkg/errors"
+	"golang.org/x/mod/semver"
+	"sigs.k8s.io/yaml"
+)
+
+type Manifest struct {
+	APIVersion     string                 `json:"apiVersion"`
+	Kind           string                 `json:"kind"`
+	RestOfManifest map[string]interface{} `json:"-"`
+}
+
+func unmarshallManifest(manifest string) (*Manifest, error) {
+	m := Manifest{}
+
+	if err := yaml.Unmarshal([]byte(manifest), &m); err != nil {
+		return nil, err
+	}
+
+	if err := yaml.Unmarshal([]byte(manifest), &m.RestOfManifest); err != nil {
+		return nil, err
+	}
+	delete(m.RestOfManifest, "kind")
+	delete(m.RestOfManifest, "apiVersion")
+
+	return &m, nil
+}
+
+func (m *Manifest) marshall() (string, error) {
+	nm, err := yaml.Marshal(m)
+	if err != nil {
+		return "", err
+	}
+	newManifest := string(nm)
+
+	rom, err := yaml.Marshal(m.RestOfManifest)
+	if err != nil {
+		return "", err
+	}
+	restOfManifest := string(rom)
+	return "---\n" + newManifest + restOfManifest, nil
+}
+
+func CheckForOldAPI(manifest string, mapping *mapping.Mapping) (string, error) {
+	m, err := unmarshallManifest(manifest)
+	if err != nil {
+		return "", err
+	}
+
+	var apiVersionStr string
+	if mapping.DeprecatedInVersion != "" {
+		apiVersionStr = mapping.DeprecatedInVersion
+	} else {
+		apiVersionStr = mapping.RemovedInVersion
+	}
+	if !semver.IsValid(apiVersionStr) {
+		return "", errors.Errorf("Failed to get the deprecated or removed Kubernetes version for API: %s %s", mapping.DeprecatedAPI.APIVersion, mapping.DeprecatedAPI.Kind)
+	}
+
+	if m.APIVersion == mapping.DeprecatedAPI.APIVersion && m.Kind == mapping.DeprecatedAPI.Kind {
+		log.Printf(
+			"Found instance of deprecated or removed Kubernetes API:\n\"%s/%s\"\nSupported API equivalent:\n\"%s/%s\"\n",
+			mapping.DeprecatedAPI.APIVersion,
+			mapping.DeprecatedAPI.Kind,
+			mapping.NewAPI.APIVersion,
+			mapping.NewAPI.Kind,
+		)
+		m.APIVersion = mapping.NewAPI.APIVersion
+		m.Kind = mapping.NewAPI.Kind
+	}
+
+	return m.marshall()
+}
+
+func SeparateDocuments(manifest string) []string {
+	lines := strings.Split(manifest, "\n")
+	documents := []string{}
+	currentDocument := []string{}
+	for _, line := range lines {
+		if line != "---" {
+			currentDocument = append(currentDocument, line)
+		} else {
+			d := strings.Join(currentDocument, "\n")
+			documents = append(documents, d)
+			currentDocument = []string{}
+		}
+	}
+
+	return documents
+}

--- a/pkg/common/manifest_test.go
+++ b/pkg/common/manifest_test.go
@@ -32,7 +32,6 @@ description: deploys kube resources
 )
 
 func TestCheckForOldAPI(t *testing.T) {
-
 	manifest, err := common.UnmarshallManifest(basicPriorityClass)
 	if err != nil {
 		t.Log(err)

--- a/pkg/common/manifest_test.go
+++ b/pkg/common/manifest_test.go
@@ -1,7 +1,6 @@
 package common_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/helm/helm-mapkubeapis/pkg/common"
@@ -21,11 +20,26 @@ metadata:
   name: important-priorityclass-critical
 value: 1000000000
 `
+
+	multidocYamlOne = `---
+app: mapkubeapis
+description: updates kube apis
+`
+	multidocYamlTwo = `---
+app: helm
+description: deploys kube resources
+`
 )
 
 func TestCheckForOldAPI(t *testing.T) {
-	manifestWithNewAPIVersion, err := common.CheckForOldAPI(
-		basicPriorityClass,
+
+	manifest, err := common.UnmarshallManifest(basicPriorityClass)
+	if err != nil {
+		t.Log(err)
+		t.Fail()
+	}
+	updated, err := common.CheckForOldAPI(
+		manifest,
 		&mapping.Mapping{
 			DeprecatedAPI: mapping.API{
 				Kind:       "PriorityClass",
@@ -37,14 +51,28 @@ func TestCheckForOldAPI(t *testing.T) {
 			},
 			RemovedInVersion: "v1.22",
 		},
+		"v1.22",
 	)
 	if err != nil {
 		t.Logf("failed to check manifest: %s", err)
 		t.Fail()
 	}
 
-	if strings.Contains(manifestWithNewAPIVersion, "scheduling.k8s.io/v1beta1") {
+	if !updated {
 		t.Logf("found the old API version in the new manifest")
+		t.Fail()
+	}
+}
+
+func TestSeparateDocuments(t *testing.T) {
+	docs := common.SeparateDocuments(multidocYamlOne + multidocYamlTwo)
+	if docs[0] != multidocYamlOne {
+		t.Logf(docs[0])
+		t.Fail()
+	}
+
+	if docs[1] != multidocYamlTwo {
+		t.Logf(docs[1])
 		t.Fail()
 	}
 }

--- a/pkg/common/manifest_test.go
+++ b/pkg/common/manifest_test.go
@@ -1,0 +1,50 @@
+package common_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/helm/helm-mapkubeapis/pkg/common"
+	"github.com/helm/helm-mapkubeapis/pkg/mapping"
+)
+
+const (
+	basicPriorityClass = `
+---
+apiVersion: scheduling.k8s.io/v1beta1
+description: important-priorityclass critical
+globalDefault: false
+kind: PriorityClass
+metadata:
+  labels:
+    team: mapkubeapis
+  name: important-priorityclass-critical
+value: 1000000000
+`
+)
+
+func TestCheckForOldAPI(t *testing.T) {
+	manifestWithNewAPIVersion, err := common.CheckForOldAPI(
+		basicPriorityClass,
+		&mapping.Mapping{
+			DeprecatedAPI: mapping.API{
+				Kind:       "PriorityClass",
+				APIVersion: "scheduling.k8s.io/v1beta1",
+			},
+			NewAPI: mapping.API{
+				Kind:       "PriorityClass",
+				APIVersion: "scheduling.k8s.io/v1",
+			},
+			RemovedInVersion: "v1.22",
+		},
+	)
+	if err != nil {
+		t.Logf("failed to check manifest: %s", err)
+		t.Fail()
+	}
+
+	if strings.Contains(manifestWithNewAPIVersion, "scheduling.k8s.io/v1beta1") {
+		t.Logf("found the old API version in the new manifest")
+		t.Fail()
+	}
+}

--- a/pkg/mapping/mapping.go
+++ b/pkg/mapping/mapping.go
@@ -32,7 +32,14 @@ type Mapping struct {
 	RemovedInVersion string `json:"removedInVersion,omitempty"`
 }
 
+// API the apiVersion and kind uniquely identify the resources being
+// updated.
 type API struct {
-	Kind       string `json:"kind"`
+	// Kind is a Kubernetes resource such as Deployment, PriorityClass, Pod that's
+	// found in an API version.
+	Kind string `json:"kind"`
+
+	// APIVersion is the version of the Kubernetes resources. This usually takes the form
+	// scheduling.k8s.io/v1beta1, extensions/v1beta1, or networking.k8s.io/v1beta1
 	APIVersion string `json:"apiVersion"`
 }

--- a/pkg/mapping/mapping.go
+++ b/pkg/mapping/mapping.go
@@ -20,14 +20,19 @@ package mapping
 // API deprecations and the new replacement API
 type Mapping struct {
 	// From is the API looking to be mapped
-	DeprecatedAPI string `json:"deprecatedAPI"`
+	DeprecatedAPI API `json:"deprecatedAPI"`
 
 	// To is the API to be mapped to
-	NewAPI string `json:"newAPI"`
+	NewAPI API `json:"newAPI"`
 
 	// Kubernetes version API is deprecated in
 	DeprecatedInVersion string `json:"deprecatedInVersion,omitempty"`
 
 	// Kubernetes version API is removed in
 	RemovedInVersion string `json:"removedInVersion,omitempty"`
+}
+
+type API struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
 }


### PR DESCRIPTION
## Description

I ran into https://github.com/helm/helm-mapkubeapis/issues/46 while trying to use this plugin. In my helm manifest, I had

```yaml
apiVersion: scheduling.k8s.io/v1beta1
description: "really cool description and totally unpredictable"
kind: PriorityClass
```

so the `strings.Contains` bit wasn't working well for me.

I updated the `Map.yaml` structure to give a better reflection of the APIs that are changing. Instead of doing a string search through the file, I specifically parse the `apiVersion` and the `kind`, then specifically compare those two fields.

```yaml
- deprecatedAPI:
    apiVersion: extensions/v1beta1
    kind: Deployment
  newAPI:
    apiVersion: apps/v1
    kind: Deployment
  deprecatedInVersion: "v1.9"
  removedInVersion: "v1.16"
```

- Also added tests. Added a target in the makefile and added it to CI
- Refactored `ReplaceManifestUnSupportedAPIs` so it was easier to test.