### PR TITLE
Add deprecation of batch/v1beta1 CronJob

### DIFF
--- a/config/Map.yaml
+++ b/config/Map.yaml
@@ -195,4 +195,8 @@ mappings:
     newAPI: "apiVersion: policy/v1\nkind: PodDisruptionBudget\n"
     deprecatedInVersion: "v1.21"
     removedInVersion: "v1.25"
+  - deprecatedAPI: "apiVersion: batch/v1beta1\nkind: CronJob\n"
+    newAPI: "apiVersion: batch/v1\nkind: CronJob\n"
+    deprecatedInVersion: "v1.21"
+    removedInVersion: "v1.25"
 


### PR DESCRIPTION
`apiVersion: batch/v1beta1 kind: CronJob` was deprecated in 1.21 and removed in 1.25.

Opening a new PR to trigger the CI as discussed in https://github.com/helm/helm-mapkubeapis/pull/80#issuecomment-1396713659

Signed-off-by: Max Rosin <git@hackrid.de>