### PR TITLE
Fix message

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -93,17 +93,15 @@ func ReplaceManifestData(mapMetadata *mapping.Metadata, modifiedManifest string,
 			return "", errors.Errorf("Failed to get the deprecated or removed Kubernetes version for API: %s", strings.ReplaceAll(deprecatedAPI, "\n", " "))
 		}
 
-		if semver.Compare(apiVersionStr, kubeVersionStr) > 0 {
-			log.Printf("The following API does not require mapping as the "+
-				"API is not deprecated or removed in Kubernetes '%s':\n\"%s\"\n", apiVersionStr,
-				deprecatedAPI)
-			// skip to next mapping
-			continue
-		}
-
 		if count := strings.Count(modifiedManifest, deprecatedAPI); count > 0 {
+			if semver.Compare(apiVersionStr, kubeVersionStr) > 0 {
+				log.Printf("The following API:\n\"%s\" does not require mapping as the "+
+					"API is not deprecated or removed in Kubernetes \"%s\"\n", deprecatedAPI, kubeVersionStr)
+				// skip to next mapping
+				continue
+			}
 			if supportedAPI == "" {
-				log.Printf("Found %d instances of deprecated or removed Kubernetes API:\n\"%s\"\n", count, deprecatedAPI)
+				log.Printf("Found %d instances of deprecated or removed Kubernetes API:\n\"%s\"\nNo supported API equivalent\n", count, deprecatedAPI)
 				modifiedManifest = removeDeprecatedAPIWithoutSuccessor(count, deprecatedAPI, modifiedManifest)
 			} else {
 				log.Printf("Found %d instances of deprecated or removed Kubernetes API:\n\"%s\"\nSupported API equivalent:\n\"%s\"\n", count, deprecatedAPI, supportedAPI)


### PR DESCRIPTION
A message similar to the one below will be shown even though the API does not exist in the Helm release manifests because it checks the API version against the Kubernetes version. This is because the check was moved in #95 outside of where it checks if the API exists in the manifest first.

```console
The following API:
"apiVersion: policy/v1beta1
kind: PodSecurityPolicy
" does not require mapping as the API is not deprecated or removed in Kubernetes "v1.24.6+k3s1"
```

**Note to Reviewers:** Could not think of an easy way to test the `stdout` in a unit test. Open to suggestions. 