### PR TITLE
Add install support for arm64 Macs

### DIFF
--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -11,7 +11,11 @@ echo "Downloading and installing helm-mapkubeapis v${version} ..."
 
 url=""
 if [ "$(uname)" = "Darwin" ]; then
-    url="https://github.com/helm/helm-mapkubeapis/releases/download/v${version}/helm-mapkubeapis_${version}_darwin_amd64.tar.gz"
+    if [ "$(uname -m)" = "arm64" ]; then
+        url="https://github.com/helm/helm-mapkubeapis/releases/download/v${version}/helm-mapkubeapis_${version}_darwin_arm64.tar.gz"
+    else
+        url="https://github.com/helm/helm-mapkubeapis/releases/download/v${version}/helm-mapkubeapis_${version}_darwin_amd64.tar.gz"
+    fi
 elif [ "$(uname)" = "Linux" ] ; then
     if [ "$(uname -m)" = "aarch64" ] || [ "$(uname -m)" = "arm64" ]; then
         url="https://github.com/helm/helm-mapkubeapis/releases/download/v${version}/helm-mapkubeapis_${version}_linux_arm64.tar.gz"


### PR DESCRIPTION
Currently when trying to install the `helm-mapkubeapis` plugin on an M1 (arm64) Mac it will download the amd64 version. While this works fine from my use of it I believe it would be useful to have the script install the native version