### PR TITLE
Fix extensions/v1beta1/Ingress's replacement

### DIFF
--- a/config/Map.yaml
+++ b/config/Map.yaml
@@ -100,7 +100,7 @@ mappings:
     deprecatedInVersion: "v1.14"
     removedInVersion: "v1.22"
   - deprecatedAPI: "apiVersion: extensions/v1beta1\nkind: Ingress\n"
-    newAPI: "apiVersion: networking.k8s.io/v1beta1\nkind: Ingress\n"
+    newAPI: "apiVersion: networking.k8s.io/v1\nkind: Ingress\n"
     deprecatedInVersion: "v1.14"
     removedInVersion: "v1.22"
   - deprecatedAPI: "apiVersion: networking.k8s.io/v1beta1\nkind: Ingress\n"


### PR DESCRIPTION
The new API version should be `networking.k8s.io/v1` as `networking.k8s.io/v1beta1` is removed in 1.22 as well