### PR TITLE
Support oidc auth provider in kubeconfig

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )


### PR DESCRIPTION
This awesome plugin does not work for our kubeconfigs wich relies on oidc as the auth provider:

```
> helm mapkubeapis --mapfile $HOME/.kube/fix-cert-manager-api.yaml galvani --dry-run
2023/04/17 12:09:56 NOTE: This is in dry-run mode, the following actions will not be executed.
2023/04/17 12:09:56 Run without --dry-run to take the actions described below:
2023/04/17 12:09:56
2023/04/17 12:09:56 Release 'galvani' will be checked for deprecated or removed Kubernetes APIs and will be updated if necessary to supported API versions.
2023/04/17 12:09:56 Get release 'galvani' latest version.
Error: failed to get release 'galvani' latest version: query: failed to query with labels: no Auth Provider found for name "oidc"
Error: plugin "mapkubeapis" exited with error
```