### PR TITLE
feat: support additional mappings apart from config

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -46,7 +46,7 @@ const UpgradeDescription = "Kubernetes deprecated API upgrade - DO NOT rollback 
 
 // ReplaceManifestUnSupportedAPIs returns a release manifest with deprecated or removed
 // Kubernetes APIs updated to supported APIs
-func ReplaceManifestUnSupportedAPIs(origManifest, mapFile string, kubeConfig KubeConfig) (string, error) {
+func ReplaceManifestUnSupportedAPIs(origManifest, mapFile string, kubeConfig KubeConfig, additionalMappings ...*mapping.Mapping) (string, error) {
 	var modifiedManifest = origManifest
 	var err error
 	var mapMetadata *mapping.Metadata
@@ -55,6 +55,8 @@ func ReplaceManifestUnSupportedAPIs(origManifest, mapFile string, kubeConfig Kub
 	if mapMetadata, err = mapping.LoadMapfile(mapFile); err != nil {
 		return "", errors.Wrapf(err, "Failed to load mapping file: %s", mapFile)
 	}
+
+	mapMetadata.Mappings = append(mapMetadata.Mappings, additionalMappings...)
 
 	// get the Kubernetes server version
 	kubeVersionStr, err := getKubernetesServerVersion(kubeConfig)

--- a/pkg/v3/release.go
+++ b/pkg/v3/release.go
@@ -26,11 +26,12 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 
 	common "github.com/helm/helm-mapkubeapis/pkg/common"
+	"github.com/helm/helm-mapkubeapis/pkg/mapping"
 )
 
 // MapReleaseWithUnSupportedAPIs checks the latest release version for any deprecated or removed APIs in its metadata
 // If it finds any, it will create a new release version with the APIs mapped to the supported versions
-func MapReleaseWithUnSupportedAPIs(mapOptions common.MapOptions) error {
+func MapReleaseWithUnSupportedAPIs(mapOptions common.MapOptions, additionalMappings ...*mapping.Mapping) error {
 	cfg, err := GetActionConfig(mapOptions.ReleaseNamespace, mapOptions.KubeConfig)
 	if err != nil {
 		return errors.Wrap(err, "failed to get Helm action configuration")
@@ -45,7 +46,7 @@ func MapReleaseWithUnSupportedAPIs(mapOptions common.MapOptions) error {
 
 	log.Printf("Check release '%s' for deprecated or removed APIs...\n", releaseName)
 	var origManifest = releaseToMap.Manifest
-	modifiedManifest, err := common.ReplaceManifestUnSupportedAPIs(origManifest, mapOptions.MapFile, mapOptions.KubeConfig)
+	modifiedManifest, err := common.ReplaceManifestUnSupportedAPIs(origManifest, mapOptions.MapFile, mapOptions.KubeConfig, additionalMappings...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Make sure to read the Contributing Guide before submitting your PR:
https://github.com/helm/helm-mapkubeapis/blob/main/CONTRIBUTING.md
2. If this PR closes another issue, add 'closes #<issue number>' somewhere in the PR summary. GitHub will automatically close that issue when this PR gets merged. Alternatively, adding 'refs #<issue number>' will not close the issue, but help provide the reviewer more context.-->

**What this PR does / why we need it**:

We would like to leverage this plugin for dealing with removed third-party API versions. By being able to inject additional mappings, we will be able to [work around](https://github.com/stackrox/stackrox/pull/14363) the issue described below. Alternatively, it _should_ also be possible to achieve what we need by instead massaging the stock map file or executing the plugin multiple times 🙈 , but this additional function argument would let us do it in an elegant manner.

A typical scenario where [our helm-based operator](https://github.com/stackrox/stackrox/tree/master/operator) gets stuck:
1. User installs istio on the cluster for experimentation. The `networking.istio.io/v1alpha3` API becomes available in the cluster.
2. Our operator reconciles a stackrox `SecuredCluster` CR. The underlying helm chart [detects the API](https://github.com/stackrox/stackrox/blob/5e51a4004e9a5cba003a69412b77854ee522131a/image/templates/helm/stackrox-secured-cluster/internal/defaults/10-env.yaml.htpl#L4-L5) and installs an [istio DestinationRule](https://github.com/stackrox/stackrox/blob/5e51a4004e9a5cba003a69412b77854ee522131a/image/templates/helm/stackrox-secured-cluster/templates/sensor.yaml.htpl#L361-L363) resource. This resource is now saved in the latest helm release.
3. User removes istio from the cluster for whatever reason. With it, they remove the istio CRDs as well. They might not be aware that another operator has started using the API.
4. Our operator runs another reconcile (for whatever reason). The underlying helm upgrade fails because the [loading of current release](https://github.com/helm/helm/blob/9fad3cd907012122465ae46cd340dd637ed429ea/pkg/action/upgrade.go#L311) fails with: `unable to build kubernetes objects from current release manifest: [resource mapping not found for name: "scanner-internal-no-istio-mtls" namespace: "stackrox" from "": no matches for kind "DestinationRule" in version "networking.istio.io/v1alpha3"
ensure CRDs are installed first,[...]`

Arguably the user should not have removed the CRDs in step (3). However a seemingly unrelated operator getting stuck at this point is not a great or expected experience.

**Special notes for your reviewer**:

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [ ] this PR has been tested for backwards compatibility
